### PR TITLE
Fix: Fake --> Freak

### DIFF
--- a/Grammar/DefuseGrammar.cs
+++ b/Grammar/DefuseGrammar.cs
@@ -44,7 +44,7 @@ namespace KTANE_Bot
             parallelPort.Append(trueOrFalse);
                 
             //frk, interpreted as the word "freak".
-            var frk = new GrammarBuilder("Fake");
+            var frk = new GrammarBuilder("Freak");
             frk.Append(trueOrFalse);
                 
             //car, interpreted as the word "car".


### PR DESCRIPTION
I had an issue where with the Bomb check, I couldn't tell the app "Freak no". It would interpret it as Fake, which didn't do anything. This fixes the issue.